### PR TITLE
fix: correct unevaluatedProperties typo in public-incoming-payment schema

### DIFF
--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -996,7 +996,7 @@ components:
           description: The URL of the authorization server endpoint for getting grants and access tokens for this wallet address.
       required:
         - authServer
-      unresolvedProperites: false
+      unevaluatedProperties: false
     outgoing-payment:
       title: Outgoing Payment
       description: 'An **outgoing payment** resource represents a payment that will be, is currently being, or has previously been, sent from the wallet address.'


### PR DESCRIPTION
## Summary

The `public-incoming-payment` schema in `resource-server.yaml` uses `unresolvedProperites: false` — a misspelling that is not a valid OpenAPI 3.1 keyword. It is silently ignored by all validators and code generators.

The intended keyword is `unevaluatedProperties: false`, which is correctly used in `auth-server.yaml` (line 478).

**Impact:** Without this fix, any code generator or validator treats the `public-incoming-payment` schema as allowing arbitrary additional properties, which defeats the intent of the constraint.

## Change

```diff
-      unresolvedProperites: false
+      unevaluatedProperties: false
```

`resource-server.yaml`, line 999